### PR TITLE
fix: 🐛 ios13 malformed sha result

### DIFF
--- a/ios/RCTCrypto/lib/Shared.m
+++ b/ios/RCTCrypto/lib/Shared.m
@@ -6,11 +6,18 @@
 
 @implementation Shared
 
-+ (NSString *) toHex:(NSData *)nsdata {
-    NSString * hexStr = [NSString stringWithFormat:@"%@", nsdata];
-    for(NSString * toRemove in [NSArray arrayWithObjects:@"<", @">", @" ", nil])
-        hexStr = [hexStr stringByReplacingOccurrencesOfString:toRemove withString:@""];
-    return hexStr;
++ (NSString *) toHex:(NSData *)data {
+    NSUInteger dataLength = data.length;
+    if (dataLength == 0) {
+        return nil;
+    }
+
+    const unsigned char *dataBuffer = data.bytes;
+    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    return [hexString copy];
 }
 
 + (NSData *) fromHex: (NSString *)string {


### PR DESCRIPTION
fixes an issue where the result is `{length32,bytes0xe91c254ad58860a02c788dfb5c1a65d6...c7db16fef4af2dec}`

based on https://github.com/trackforce/react-native-crypto/pull/11/files